### PR TITLE
Bug de descuento de cantidad arreglado,

### DIFF
--- a/Infrastructure/Data/Repos/PedidoRepo.cs
+++ b/Infrastructure/Data/Repos/PedidoRepo.cs
@@ -61,7 +61,10 @@ namespace Infrastructure.Data.Repos
 
                 await _pedidoMicaRepo.AddPedidoMica(pedidosMicas);
 
-                await _loteRepo.TakeExistencias(pedidosMicas.First().IdLoteOrigen, pedidosMicas.Sum(pm => pm.Cantidad));
+                foreach(var pm in pedidosMicas)
+                {
+                    await _loteRepo.TakeExistencias(pm.IdLoteOrigen, pm.Cantidad);
+                }
 
                 Console.WriteLine("Pedido añadido, id: " + pedido.Id + ", con " + pedidosMicas.Count() + " graduaciones");
 


### PR DESCRIPTION
el pedo era la linea:
                await _loteRepo.TakeExistencias(pedidosMicas.First().IdLoteOrigen, pedidosMicas.Sum(pm => pm.Cantidad));

que habia puesto para probarlo asi rapido, con logica incorrecta xd, pero lo corregi ya iterando fila por fila y restando cada cantidad a la entidad correspondiente

foreach(var pm in pedidosMicas)
{
    await _loteRepo.TakeExistencias(pm.IdLoteOrigen, pm.Cantidad);
}